### PR TITLE
Bump Version to svn1108

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vlmcsd
-PKG_VERSION=svn1107
+PKG_VERSION=svn1108
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Wind4


### PR DESCRIPTION
2017-01-19 (1108)

- Fixed a bug that Android x86/x64 builds terminated with SIGILL (illegal instruction) if run from a non-Atom CPU (thx to Daz)
- New option -x1 (requested by Hahu) that causes vlmcsd to exit if
  - any of the listening sockets (IP address / port) specified with -L cannot be setup.
  - the TAP mirror thread encounters an error reading from or writing to the VPN adapter.
- New INI file directive ExitLevel = 1 that does the same as -x1