### PR TITLE
bump version to svn1111 and update LEDE ImageBuilder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,21 +16,21 @@ env:
   - REPO=openwrt-vlmcsd
   matrix:
   - OSVER=OpenWrt   SDK_URL=https://downloads.openwrt.org/chaos_calmer/15.05.1/ar71xx/generic/OpenWrt-SDK-15.05.1-ar71xx-generic_gcc-4.8-linaro_uClibc-0.9.33.2.Linux-x86_64.tar.bz2
-  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.1/targets/ar71xx/nand/lede-sdk-17.01.1-ar71xx-nand_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
+  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.4/targets/ar71xx/nand/lede-sdk-17.01.4-ar71xx-nand_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
   - OSVER=OpenWrt   SDK_URL=https://downloads.openwrt.org/chaos_calmer/15.05.1/ramips/mt7620/OpenWrt-SDK-15.05.1-ramips-mt7620_gcc-4.8-linaro_uClibc-0.9.33.2.Linux-x86_64.tar.bz2
-  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.1/targets/ramips/mt7620/lede-sdk-17.01.1-ramips-mt7620_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
+  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.4/targets/ramips/mt7620/lede-sdk-17.01.4-ramips-mt7620_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
   - OSVER=OpenWrt   SDK_URL=https://downloads.openwrt.org/chaos_calmer/15.05.1/brcm63xx/generic/OpenWrt-SDK-15.05.1-brcm63xx-generic_gcc-4.8-linaro_uClibc-0.9.33.2.Linux-x86_64.tar.bz2
-  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.1/targets/brcm63xx/generic/lede-sdk-17.01.1-brcm63xx-generic_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
+  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.4/targets/brcm63xx/generic/lede-sdk-17.01.4-brcm63xx-generic_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
   - OSVER=OpenWrt   SDK_URL=https://downloads.openwrt.org/chaos_calmer/15.05.1/bcm53xx/generic/OpenWrt-SDK-15.05.1-bcm53xx_gcc-4.8-linaro_uClibc-0.9.33.2_eabi.Linux-x86_64.tar.bz2
-  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.1/targets/bcm53xx/generic/lede-sdk-17.01.1-bcm53xx_gcc-5.4.0_musl-1.1.16_eabi.Linux-x86_64.tar.xz
+  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.4/targets/bcm53xx/generic/lede-sdk-17.01.4-bcm53xx_gcc-5.4.0_musl-1.1.16_eabi.Linux-x86_64.tar.xz
   - OSVER=OpenWrt   SDK_URL=https://downloads.openwrt.org/chaos_calmer/15.05.1/brcm47xx/generic/OpenWrt-SDK-15.05.1-brcm47xx-generic_gcc-4.8-linaro_uClibc-0.9.33.2.Linux-x86_64.tar.bz2
-  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.1/targets/brcm47xx/generic/lede-sdk-17.01.1-brcm47xx-generic_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
+  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.4/targets/brcm47xx/generic/lede-sdk-17.01.4-brcm47xx-generic_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
   - OSVER=OpenWrt   SDK_URL=https://downloads.openwrt.org/chaos_calmer/15.05.1/mvebu/generic/OpenWrt-SDK-15.05.1-mvebu_gcc-4.8-linaro_uClibc-0.9.33.2_eabi.Linux-x86_64.tar.bz2
-  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.1/targets/mvebu/generic/lede-sdk-17.01.1-mvebu_gcc-5.4.0_musl-1.1.16_eabi.Linux-x86_64.tar.xz
+  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.4/targets/mvebu/generic/lede-sdk-17.01.4-mvebu_gcc-5.4.0_musl-1.1.16_eabi.Linux-x86_64.tar.xz
   - OSVER=OpenWrt   SDK_URL=https://downloads.openwrt.org/chaos_calmer/15.05.1/x86/generic/OpenWrt-SDK-15.05.1-x86-generic_gcc-4.8-linaro_uClibc-0.9.33.2.Linux-x86_64.tar.bz2
-  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.1/targets/x86/generic/lede-sdk-17.01.1-x86-generic_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
+  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.4/targets/x86/generic/lede-sdk-17.01.4-x86-generic_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
   - OSVER=OpenWrt   SDK_URL=https://downloads.openwrt.org/chaos_calmer/15.05.1/x86/64/OpenWrt-SDK-15.05.1-x86-64_gcc-4.8-linaro_uClibc-0.9.33.2.Linux-x86_64.tar.bz2
-  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.1/targets/x86/64/lede-sdk-17.01.1-x86-64_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
+  - OSVER=LEDE      SDK_URL=https://downloads.lede-project.org/releases/17.01.4/targets/x86/64/lede-sdk-17.01.4-x86-64_gcc-5.4.0_musl-1.1.16.Linux-x86_64.tar.xz
 install:
 - mkdir -p $TRAVIS_BUILD_DIR/local ; cd $TRAVIS_BUILD_DIR/local
 - wget "http://archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.3.4-1_amd64.deb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
 - find . -name *vlmcsd*.ipk -exec cp {} $TRAVIS_BUILD_DIR \;
 - cd $TRAVIS_BUILD_DIR/
 - chmod a+x $TRAVIS_BUILD_DIR/deploy.sh
-after_success: "$TRAVIS_BUILD_DIR/deploy.sh"
+#after_success: "$TRAVIS_BUILD_DIR/deploy.sh"
 before_deploy: git fetch --tags
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
 - find . -name *vlmcsd*.ipk -exec cp {} $TRAVIS_BUILD_DIR \;
 - cd $TRAVIS_BUILD_DIR/
 - chmod a+x $TRAVIS_BUILD_DIR/deploy.sh
-#after_success: "$TRAVIS_BUILD_DIR/deploy.sh"
+after_success: "$TRAVIS_BUILD_DIR/deploy.sh"
 before_deploy: git fetch --tags
 deploy:
   provider: releases

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vlmcsd
-PKG_VERSION=svn1110
+PKG_VERSION=svn1111
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=HotBird64


### PR DESCRIPTION
2017-06-17 (**1111**)
- Support for Windows Professional Workstation and Windows Professional Workstation N (aka Win 10 Pro for Advanced PCs)
  - Updated vlmcsd.kmd
  - Updated internal databases of vlmcs and vlmcsdmulti
- Some internal code optimizations